### PR TITLE
Script errors log with debugMode

### DIFF
--- a/src/jquery.html5Loader.js
+++ b/src/jquery.html5Loader.js
@@ -362,7 +362,8 @@
         defer.resolve();
       })
       .fail(function(jqxhr, settings, exception) {
-        log('File Failed:' + file.source, exception);
+        log('\n File Failed: ' + file.source + 
+            '\n Message:     ' + exception.message + '\n');
       });
 
       return defer.promise();


### PR DESCRIPTION
Helps you cypher out those mysterious _unloaded_ **script** files that happen to contain javascript errors. 
Can see this via `debugMode : true`.
